### PR TITLE
LocalStorage entry

### DIFF
--- a/cypress/integration/example.spec.js
+++ b/cypress/integration/example.spec.js
@@ -30,7 +30,7 @@ context('Example', () => {
 
       cy.window().then((win) => {
         win.localStorage.setItem(
-            `@@auth0spajs@@::${client_id}::${audience}::${scope}`,
+            `@@auth0spajs@@::${client_id}::${audience}::${scope}`, // Could also be ::default:: instead of ::${audience}::
             JSON.stringify({
               body: {
                 client_id,


### PR DESCRIPTION
In our case we checked the auth0spa entry when localStorage is enabled on our website and discovered that it contained default rather than the audience.